### PR TITLE
Refactor archimedes configuration of angular example

### DIFF
--- a/examples/example-angular/src/app/app.module.ts
+++ b/examples/example-angular/src/app/app.module.ts
@@ -1,34 +1,21 @@
-import { ApplicationRef, DoBootstrap, Injector, NgModule } from '@angular/core'
+import { NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 import { AppComponent } from './app.component'
 import { FooCmd } from './foo-cmd'
 import { BarQry } from './bar-qry'
-import { Runner, CacheInvalidations, CacheLink, CacheManager, ExecutorLink, LoggerLink, Logger } from '@archimedes/arch'
+import { CacheInvalidations } from '@archimedes/arch'
 import { QuxCmd } from './qux-cmd'
 import { BazQry } from './baz-qry'
+import { ArchimedesModule } from 'src/core/modules/archimedes/archimedes.module'
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule],
-  providers: [
-    { provide: LoggerLink, useFactory: () => new LoggerLink(console) },
-    { provide: ExecutorLink, useClass: ExecutorLink },
-    { provide: CacheManager, useClass: CacheManager },
-    { provide: CacheLink, useClass: CacheLink, deps: [CacheManager] }
-  ]
+  imports: [BrowserModule, ArchimedesModule],
+  bootstrap: [AppComponent]
 })
-export class AppModule implements DoBootstrap {
-  constructor(private readonly injector: Injector) {}
-
-  ngDoBootstrap(applicationRef: ApplicationRef) {
-    const cacheLink = this.injector.get(CacheLink)
-    const loggerLink = this.injector.get(LoggerLink)
-    const executorLink = this.injector.get(ExecutorLink)
-
+export class AppModule {
+  constructor() {
     CacheInvalidations.set(FooCmd.name, [BarQry.name])
     CacheInvalidations.set(QuxCmd.name, [BazQry.name])
-
-    Runner.createChain([cacheLink, executorLink, loggerLink])
-    applicationRef.bootstrap(AppComponent)
   }
 }

--- a/examples/example-angular/src/core/modules/archimedes/archimedes.module.ts
+++ b/examples/example-angular/src/core/modules/archimedes/archimedes.module.ts
@@ -1,0 +1,26 @@
+import { CacheLink, CacheManager, ExecutorLink, LoggerLink, Runner } from '@archimedes/arch'
+import { CommonModule } from '@angular/common'
+import { APP_INITIALIZER, NgModule } from '@angular/core'
+
+const ARCHIMEDES_PROVIDERS = [
+  { provide: LoggerLink, useFactory: () => new LoggerLink(console) },
+  { provide: ExecutorLink, useClass: ExecutorLink },
+  { provide: CacheManager, useClass: CacheManager },
+  { provide: CacheLink, useClass: CacheLink, deps: [CacheManager] }
+]
+
+@NgModule({
+  imports: [CommonModule],
+  providers: [
+    ...ARCHIMEDES_PROVIDERS,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (cacheLink: CacheLink, executorLink: ExecutorLink, loggerLink: LoggerLink) => () => {
+        return Runner.createChain([cacheLink, executorLink, loggerLink])
+      },
+      deps: [CacheLink, ExecutorLink, LoggerLink],
+      multi: true
+    }
+  ]
+})
+export class ArchimedesModule {}


### PR DESCRIPTION
This pull request, cleans up the code from the angular example. 
I have moved the archimedes configuration to its own module and used the [APP_INITIALIZER](https://angular.io/api/core/APP_INITIALIZER) token to initialize the runner at application startup.