### PR TITLE
Invalidate cache in runtime

### DIFF
--- a/packages/arch/src/runner/links/cache-link.spec.ts
+++ b/packages/arch/src/runner/links/cache-link.spec.ts
@@ -9,7 +9,7 @@ import { InvalidationPolicy } from '../../cache/invalidation-policy'
 import { Command } from '../../use-case/command'
 
 describe('CacheLink', () => {
-  it('should use the cache', async () => {
+  it('should not use the cache when cache manager has not this execution registered', async () => {
     const { link, cacheManager, cacheLink } = setup()
     when(cacheManager.has(anything(), anything())).thenReturn(false)
 

--- a/packages/arch/src/runner/links/cache-link.spec.ts
+++ b/packages/arch/src/runner/links/cache-link.spec.ts
@@ -31,6 +31,28 @@ describe('CacheLink', () => {
     verify(link.next(anything())).once()
   })
 
+  it("should not use the cache when 'invalidateCache' flag is true", async () => {
+    const { link, cacheManager, cacheLink } = setup()
+
+    class MockUseCase extends UseCase<unknown, unknown> {
+      readonly = true
+
+      async internalExecute(): Promise<void> {}
+    }
+
+    const context = Context.create({
+      useCase: new MockUseCase(),
+      param: undefined,
+      executionOptions: { inlineError: false, invalidateCache: true }
+    })
+    cacheLink.setNext(instance(link))
+
+    await cacheLink.next(context)
+
+    verify(link.next(anything())).once()
+    verify(cacheManager.has(anything(), anything())).never()
+  })
+
   it('should break the link if it is cached', async () => {
     const { link, cacheManager, cacheLink } = setup()
     when(cacheManager.has(anything(), anything())).thenReturn(true)

--- a/packages/arch/src/runner/links/cache-link.ts
+++ b/packages/arch/src/runner/links/cache-link.ts
@@ -13,7 +13,7 @@ export class CacheLink extends BaseLink {
   async next(context: Context): Promise<void> {
     const name = context.useCase.constructor.name
 
-    if (!this.cacheManager.has(name, [context.param])) {
+    if (context.executionOptions.invalidateCache || !this.cacheManager.has(name, [context.param])) {
       this.nextLink.next(context)
     }
 

--- a/packages/arch/src/use-case/execution-options.ts
+++ b/packages/arch/src/use-case/execution-options.ts
@@ -1,3 +1,4 @@
 export interface ExecutionOptions {
   inlineError: boolean
+  invalidateCache: boolean
 }


### PR DESCRIPTION
At this moment if you want to invalidate the cache for a specific Query in runtime and you don't have a Command you will need to do:

```
this.cacheManager.invalidateCache(FooQry.name)
this.fooQry.execute()
```

With this change you can do it easy in one step:

```
this.fooQry.execute(undefined, {invalidateCache: true})
```